### PR TITLE
Add options to prevent compilation error on Java 24

### DIFF
--- a/pde/.mvn/jvm.config
+++ b/pde/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0


### PR DESCRIPTION
Newer versions of Java have added a limit to the size. This causes a compilation error when compiling the Java code, since some of the Tycho-related XML files are very large. Increasing this limit through an option allows the Java code to be compiled properly on Java 24 and newer.

See https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3465#issuecomment-2959641987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated build JVM configuration to disable XML entity size limits, improving reliability when processing large XML resources during builds and CI pipelines.
  - No impact on runtime features or public APIs; application behavior remains unchanged.
  - Reduces build-time failures and improves developer productivity. End users should not notice any functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->